### PR TITLE
Composit Bucket and Model integration

### DIFF
--- a/src/Model/Aggregations/Bucket/Composite.php
+++ b/src/Model/Aggregations/Bucket/Composite.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace AviationCode\Elasticsearch\Model\Aggregations\Bucket;
+
+/**
+ * @property array|null $after_key
+ */
+class Composite extends Bucket
+{
+}

--- a/src/Query/Aggregations/Aggregation.php
+++ b/src/Query/Aggregations/Aggregation.php
@@ -33,7 +33,7 @@ use Illuminate\Support\Str;
  * @method Bucket\AdjacencyMatrix adjacencyMatrix(string $key, array $filters = [])
  * @method Bucket\AutoDateHistogram autoDateHistogram(string $key, string $field, array $options = [])
  * @method Bucket\Children children(string $key, string $type)
- * @todo composite
+ * @method Bucket\Composite composite(string $key, array $sources = [], array $options = [])
  * @method Bucket\DateHistogram dateHistogram(string $key, string $field, string $interval, string $intervalType = Bucket\DateHistogram::FIXED, array $options = [])
  * @method Bucket\DateRange dateRange(string $key, string $field, array $ranges, array $options = [])
  * @method Bucket\DiversifiedSampler diversifiedSampler(string $key, ?int $shardSize = null, ?string $field = null, ?int $maxDocsPerValue = null))

--- a/src/Query/Aggregations/Bucket/Composite.php
+++ b/src/Query/Aggregations/Bucket/Composite.php
@@ -58,6 +58,13 @@ class Composite extends Bucket
         return $this;
     }
 
+    public function options(array $options = []): self
+    {
+        $this->options = array_merge($this->options, $this->allowedOptions($options));
+
+        return $this;
+    }
+
     protected function toElastic(): array
     {
         $mappedSources = [];

--- a/src/Query/Aggregations/Bucket/Composite.php
+++ b/src/Query/Aggregations/Bucket/Composite.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace AviationCode\Elasticsearch\Query\Aggregations\Bucket;
+
+class Composite extends Bucket
+{
+    /** @var array */
+    protected $sources;
+
+    /** @var array */
+    protected $options = [];
+
+    protected $allowedAggregations = [
+        Terms::class,
+        Histogram::class,
+        DateHistogram::class,
+        GeotileGrid::class,
+    ];
+
+    protected $allowedOptions = [
+        'size',
+        'after',
+    ];
+
+    public function __construct(array $sources = [], array $options = [])
+    {
+        parent::__construct('composite');
+
+        $this->sources = $sources;
+        $this->options = $options;
+    }
+
+    public function addTermsSource(string $key, Terms $terms): self
+    {
+        $this->sources[$key] = $terms;
+
+        return $this;
+    }
+
+    public function addHistogramSource(string $key, Histogram $histogram): self
+    {
+        $this->sources[$key] = $histogram;
+
+        return $this;
+    }
+
+    public function addDateHistogramSource(string $key, DateHistogram $dateHistogram): self
+    {
+        $this->sources[$key] = $dateHistogram;
+
+        return $this;
+    }
+
+    public function addGeoTileGridSource(string $key, GeotileGrid $geoTileGrid): self
+    {
+        $this->sources[$key] = $geoTileGrid;
+
+        return $this;
+    }
+
+    protected function toElastic(): array
+    {
+        $mappedSources = [];
+        foreach ($this->sources as $key => $aggregation) {
+            if (!$aggregation instanceof Bucket) {
+                continue;
+            }
+
+            if (!in_array(get_class($aggregation), $this->allowedAggregations)) {
+                continue;
+            }
+
+            if (!is_string($key)) {
+                continue;
+            }
+
+            $mappedSources[] = [$key => $aggregation->toArray()];
+        }
+
+        if (!count($mappedSources)) {
+            throw new \InvalidArgumentException('No valid sources were provided.');
+        }
+
+        return array_merge(
+            ['sources' => $mappedSources],
+            $this->allowedOptions($this->options)
+        );
+    }
+}

--- a/tests/Unit/Model/Aggregations/Bucket/CompositeTest.php
+++ b/tests/Unit/Model/Aggregations/Bucket/CompositeTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace AviationCode\Elasticsearch\Tests\Unit\Model\Aggregations\Bucket;
+
+use AviationCode\Elasticsearch\Model\Aggregations\Bucket\Composite;
+use AviationCode\Elasticsearch\Tests\Unit\TestCase;
+
+class CompositeTest extends TestCase
+{
+    /** @test */
+    public function it_can_construct_a_composite_instance()
+    {
+        $composite = new Composite(
+            [
+                'buckets' => [
+                    [
+                        'key' => [
+                            'some_field_name' => 'value1',
+                        ],
+                        'doc_count' => 10,
+                    ],
+                    [
+                        'key' => [
+                            'some_field_name' => 'value2',
+                            'some_other_field_name' => 'value2B',
+                        ],
+                        'doc_count' => 99,
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertCount(2, $composite);
+        $this->assertSame('value2', $composite->get(1)->key->some_field_name);
+        $this->assertSame('value2B', $composite->get(1)->key->some_other_field_name);
+        $this->assertSame(10, $composite->get(0)->doc_count);
+        $this->assertNull($composite->after_key);
+    }
+
+    /** @test */
+    public function it_parses_the_after_key()
+    {
+        $composite = new Composite(
+            [
+                'buckets' => [
+                    [
+                        'key' => [
+                            'field_name' => 'value',
+                        ],
+                        'doc_count' => 10,
+                    ],
+                ],
+                'after_key' => [
+                    'field_name' => 'value',
+                ],
+            ]
+        );
+
+        $this->assertCount(1, $composite);
+        $this->assertEquals(10, $composite->get(0)->doc_count);
+        $this->assertEquals(['field_name' => 'value'], $composite->after_key);
+    }
+}

--- a/tests/Unit/Query/Aggregations/Bucket/CompositeTest.php
+++ b/tests/Unit/Query/Aggregations/Bucket/CompositeTest.php
@@ -115,17 +115,17 @@ class CompositeTest extends TestCase
 
         $agg
             ->composite('composite_test')
-            ->addTermsSource('street_source', new Terms('street_field'))
+            ->addTermsSource('street_field', new Terms('street_field'))
             ->addHistogramSource(
-                'histogram_source',
+                'histogram_field',
                 new Histogram('histogram_field', 2, ['order' => 'desc'])
             )
             ->addDateHistogramSource(
-                'date_histogram_source',
+                'date_histogram_field',
                 new DateHistogram('date_histogram_field', '1d')
             )
             ->addGeoTileGridSource(
-                'geo_tile_grid_source',
+                'geo_tile_grid_field',
                 new GeotileGrid('geo_tile_grid_field')
             );
 
@@ -135,14 +135,14 @@ class CompositeTest extends TestCase
                     'composite' => [
                         'sources' => [
                             [
-                                'street_source' => [
+                                'street_field' => [
                                     'terms' => [
                                         'field' => 'street_field',
                                     ],
                                 ],
                             ],
                             [
-                                'histogram_source' => [
+                                'histogram_field' => [
                                     'histogram' => [
                                         'field' => 'histogram_field',
                                         'interval' => 2,
@@ -151,7 +151,7 @@ class CompositeTest extends TestCase
                                 ],
                             ],
                             [
-                                'date_histogram_source' => [
+                                'date_histogram_field' => [
                                     'date_histogram' => [
                                         'field' => 'date_histogram_field',
                                         'fixed_interval' => '1d',
@@ -159,13 +159,45 @@ class CompositeTest extends TestCase
                                 ],
                             ],
                             [
-                                'geo_tile_grid_source' => [
+                                'geo_tile_grid_field' => [
                                     'geotile_grid' => [
                                         'field' => 'geo_tile_grid_field',
                                     ],
                                 ],
                             ],
                         ],
+                    ],
+                ],
+            ],
+            $agg->toArray()
+        );
+    }
+
+    /** @test */
+    public function it_can_add_options_dynamically()
+    {
+        $agg = new Aggregation();
+
+        $agg
+            ->composite('composite_1', [], ['size' => 10])
+            ->addTermsSource('terms_field', new Terms('terms_field'))
+            ->options(['size' => 200, 'after' => ['terms_field' => 'terms_value'], 'invalid_key' => 'value']);
+
+        $this->assertEquals(
+            [
+                'composite_1' => [
+                    'composite' => [
+                        'sources' => [
+                            [
+                                'terms_field' => [
+                                    'terms' => [
+                                        'field' => 'terms_field',
+                                    ],
+                                ],
+                            ],
+                        ],
+                        'size' => 200,
+                        'after' => ['terms_field' => 'terms_value'],
                     ],
                 ],
             ],

--- a/tests/Unit/Query/Aggregations/Bucket/CompositeTest.php
+++ b/tests/Unit/Query/Aggregations/Bucket/CompositeTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace AviationCode\Elasticsearch\Tests\Unit\Query\Aggregations\Bucket;
+
+use AviationCode\Elasticsearch\Query\Aggregations\Aggregation;
+use AviationCode\Elasticsearch\Query\Aggregations\Bucket\DateHistogram;
+use AviationCode\Elasticsearch\Query\Aggregations\Bucket\GeotileGrid;
+use AviationCode\Elasticsearch\Query\Aggregations\Bucket\Histogram;
+use AviationCode\Elasticsearch\Query\Aggregations\Bucket\Terms;
+use AviationCode\Elasticsearch\Query\Dsl\Term\Range;
+use AviationCode\Elasticsearch\Tests\Unit\TestCase;
+
+class CompositeTest extends TestCase
+{
+    /** @test */
+    public function it_builds_a_composite_aggregation()
+    {
+        $agg = new Aggregation();
+
+        $agg->composite('composite_1', ['terms_1' => new Terms('terms_field_1')]);
+        $agg->composite('composite_2', ['terms_2' => new Terms('terms_field_2')], ['size' => 2]);
+        $agg->composite(
+            'composite_3',
+            ['terms_3' => new Terms('terms_field_3')],
+            ['after' => ['terms_3' => 'after_value']]
+        );
+
+        $this->assertEquals(
+            [
+                'composite_1' => [
+                    'composite' => [
+                        'sources' => [
+                            [
+                                'terms_1' => [
+                                    'terms' => ['field' => 'terms_field_1'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'composite_2' => [
+                    'composite' => [
+                        'sources' => [
+                            [
+                                'terms_2' => [
+                                    'terms' => ['field' => 'terms_field_2'],
+                                ],
+                            ],
+                        ],
+                        'size' => 2,
+                    ],
+                ],
+                'composite_3' => [
+                    'composite' => [
+                        'sources' => [
+                            [
+                                'terms_3' => [
+                                    'terms' => ['field' => 'terms_field_3'],
+                                ],
+                            ],
+                        ],
+                        'after' => [
+                            'terms_3' => 'after_value',
+                        ],
+                    ],
+                ],
+            ],
+            $agg->toArray()
+        );
+    }
+
+    /** @test */
+    public function it_filters_out_invalid_sources()
+    {
+        $agg = new Aggregation();
+
+        $agg->composite(
+            'composite_1',
+            [
+                'terms1' => new Terms('terms_field_1'),
+                'range_1' => new Range('range_field'),
+            ]
+        );
+
+        $this->assertEquals(
+            [
+                'composite_1' => [
+                    'composite' => [
+                        'sources' => [
+                            [
+                                'terms1' => [
+                                    'terms' => ['field' => 'terms_field_1'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $agg->toArray()
+        );
+    }
+
+    /** @test */
+    public function it_can_throw_an_invalid_argument_exception()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        (new Aggregation())->composite('test_composite')->toArray();
+    }
+
+    /** @test */
+    public function it_can_add_sources_dynamically()
+    {
+        $agg = new Aggregation();
+
+        $agg
+            ->composite('composite_test')
+            ->addTermsSource('street_source', new Terms('street_field'))
+            ->addHistogramSource(
+                'histogram_source',
+                new Histogram('histogram_field', 2, ['order' => 'desc'])
+            )
+            ->addDateHistogramSource(
+                'date_histogram_source',
+                new DateHistogram('date_histogram_field', '1d')
+            )
+            ->addGeoTileGridSource(
+                'geo_tile_grid_source',
+                new GeotileGrid('geo_tile_grid_field')
+            );
+
+        $this->assertEquals(
+            [
+                'composite_test' => [
+                    'composite' => [
+                        'sources' => [
+                            [
+                                'street_source' => [
+                                    'terms' => [
+                                        'field' => 'street_field',
+                                    ],
+                                ],
+                            ],
+                            [
+                                'histogram_source' => [
+                                    'histogram' => [
+                                        'field' => 'histogram_field',
+                                        'interval' => 2,
+                                        'order' => 'desc',
+                                    ],
+                                ],
+                            ],
+                            [
+                                'date_histogram_source' => [
+                                    'date_histogram' => [
+                                        'field' => 'date_histogram_field',
+                                        'fixed_interval' => '1d',
+                                    ],
+                                ],
+                            ],
+                            [
+                                'geo_tile_grid_source' => [
+                                    'geotile_grid' => [
+                                        'field' => 'geo_tile_grid_field',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $agg->toArray()
+        );
+    }
+}


### PR DESCRIPTION
resolves #54 

- Adds support for constructing a Composite Bucket Aggregation (and parsing it from the response). 
- Composite Model is a simple extension of the base Bucket Model, with the addition of an `after_key` - property 

**Example usage (Fluent methods)**

```php
$query
    ->aggregations()
    ->composite('terms_composite')
    ->addTermsSource('terms_field', new Terms('terms_field', ['order' => 'asc']))
    ->options(array_merge(['size' => 200], array_filter(['after' => $after])));
```

**Example usage (through composite method only)**

```php
$query
    ->aggregations()
    ->composite(
        'terms_composite', 
        [
            'terms_field' => new Terms('terms_field'),
            'other_terms_field' => new Terms('other_terms_field')
        ],
        array_merge(['size' => 200], array_filter(['after' => $after]))
    );
```

Personal thought, would be cleaner if the Terms, Histogram, DateHistogram and GeotileGrid should have a public function for accessing the field. This way we don't have to pass it along twice when working with Composite Bucket aggregations. Didn't implement it yet because I first wanted your opinion on it. 

Also haven't updated the changelog or composer.json version. Is version `0.10.0` be good for you? 
