### PR TITLE
Fallback when type isn't defined

### DIFF
--- a/src/Console/CreateIndexCommand.php
+++ b/src/Console/CreateIndexCommand.php
@@ -41,7 +41,7 @@ class CreateIndexCommand extends Command
         $this->table(
             ['Field', 'Type', 'Options'],
             collect($model->getSearchMapping())->map(function ($mapping, $field) {
-                $type = $mapping['type'];
+                $type = $mapping['type'] ?? '-';
                 unset($mapping['type']);
 
                 return [$field, $type, json_encode($mapping)];


### PR DESCRIPTION
When defining the mapping, it isn't always necessary to provide the type 

Example below is a valid config, but throws an exception with the current code as the `type` key isn't defined
```php
'objectField' => [
    'properties' => [
        'subField' => ['type' => 'keyword'],
        'subField2' => ['type' => 'integer'],
    ]
]
```