### PR TITLE
Fetch aggregations from  SimplePaginator

### DIFF
--- a/src/Pagination/SimplePaginator.php
+++ b/src/Pagination/SimplePaginator.php
@@ -2,6 +2,7 @@
 
 namespace AviationCode\Elasticsearch\Pagination;
 
+use AviationCode\Elasticsearch\Model\Aggregations\Aggregation;
 use AviationCode\Elasticsearch\Model\ElasticCollection;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
@@ -32,5 +33,10 @@ class SimplePaginator extends LengthAwarePaginator
         if ($this->items->total_relation == 'gte') {
             $this->lastPage--;
         }
+    }
+
+    public function aggregations(): Aggregation
+    {
+        return $this->items->aggregations;
     }
 }

--- a/tests/Unit/Pagination/SimplePaginatorTest.php
+++ b/tests/Unit/Pagination/SimplePaginatorTest.php
@@ -2,13 +2,17 @@
 
 namespace AviationCode\Elasticsearch\Tests\Unit\Pagination;
 
+use AviationCode\Elasticsearch\Model\Aggregations\Aggregation;
+use AviationCode\Elasticsearch\Model\Aggregations\Bucket\Bucket;
 use AviationCode\Elasticsearch\Model\ElasticCollection;
 use AviationCode\Elasticsearch\Pagination\SimplePaginator;
+use AviationCode\Elasticsearch\Query\Aggregations\Bucket\Terms;
 use AviationCode\Elasticsearch\Tests\Feature\TestCase;
+use ReflectionMethod;
 
 class SimplePaginatorTest extends TestCase
 {
-    /** @test **/
+    /** @test * */
     public function it_builds_a_simple_paginator()
     {
         $response = [
@@ -64,5 +68,98 @@ class SimplePaginatorTest extends TestCase
         $this->assertEquals(1, $paginator->currentPage());
         $this->assertEquals(10000, $paginator->total());
         $this->assertEquals(9, $paginator->lastPage());
+    }
+
+    /** @test */
+    public function it_has_a_method_to_retrieve_the_aggregations_from_the_elastic_collection()
+    {
+        $aggregationsMethod = new ReflectionMethod(SimplePaginator::class, 'aggregations');
+
+        $this->assertTrue($aggregationsMethod->isPublic());
+        $this->assertSame(Aggregation::class, $aggregationsMethod->getReturnType()->getName());
+        $this->assertSame(0, $aggregationsMethod->getNumberOfParameters());
+    }
+
+    /** @test */
+    public function it_can_retrieve_the_aggregations()
+    {
+        $response = [
+            'took' => 1,
+            'timed_out' => false,
+            '_shards' => [
+                'total' => 1,
+                'successful' => 1,
+                'skipped' => 0,
+                'failed' => 0,
+            ],
+            'hits' => [
+                'total' => [
+                    'value' => 10000,
+                    'relation' => 'gte',
+                ],
+                'max_score' => 1.0,
+                'hits' => [
+                    [
+                        '_index' => 'article',
+                        '_type' => '_doc',
+                        '_id' => 1,
+                        '_score' => 1.0,
+                        '_source' => [
+                            'id' => 1,
+                            'title' => 'My first title',
+                            'body' => 'My first body',
+                            'created_at' => '2019-12-20 12:00:00',
+                            'updated_at' => '2019-12-20 12:00:00',
+                        ],
+                    ],
+                    [
+                        '_index' => 'article',
+                        '_type' => '_doc',
+                        '_id' => 2,
+                        '_score' => 1.0,
+                        '_source' => [
+                            'id' => 2,
+                            'title' => 'My second title',
+                            'body' => 'My second body',
+                            'created_at' => '2019-12-21 12:00:00',
+                            'updated_at' => '2019-12-21 12:00:00',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = ElasticCollection::parse($response);
+        $aggregations = (new SimplePaginator($result, 1000, 1))->aggregations();
+
+        $this->assertInstanceOf(Aggregation::class, $aggregations);
+        $this->assertCount(0, $aggregations->toArray());
+
+        $response = array_merge(
+            $response,
+            [
+                'aggregations' => [
+                    'terms#example_aggregation' => [
+                        'doc_count_error_upper_bound' => 0,
+                        'sum_other_doc_count' => 0,
+                        'buckets' => [
+                            [
+                                'key' => 'ExampleValue',
+                                'doc_count' => 10,
+                            ],
+                            [
+                                'key' => 'ExampleValue2',
+                                'doc_count' => 1,
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $aggregations = (new SimplePaginator(ElasticCollection::parse($response), 1000, 1))->aggregations();
+        $this->assertCount(1, $aggregations->toArray());
+        $this->assertInstanceOf(Bucket::class, $aggregations->get('example_aggregation'));
+        $this->assertCount(2, $aggregations->get('example_aggregation'));
     }
 }


### PR DESCRIPTION
This PR creates the possibility to retrieve the Aggregations from the `$items` property, being an ElasticCollection instance. 